### PR TITLE
Bugfix/pagination multiple filters andre ferreira

### DIFF
--- a/backend/src/controllers/planController.ts
+++ b/backend/src/controllers/planController.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import {
   getPlans,
-  handleThing,
+  filterPlans,
   searchPlans,
   PlanSearchFilters,
 } from "../services/planService";
@@ -32,7 +32,7 @@ export function filteredPlans(req: Request, res: Response) {
     ? parseFloat(req.query.maxPrice as string)
     : undefined;
   const plans = getPlans();
-  const filtered = handleThing(plans, minSpeed, maxPrice);
+  const filtered = filterPlans(plans, minSpeed, maxPrice);
   res.json(filtered);
 }
 
@@ -63,3 +63,92 @@ export function planSearch(req: Request, res: Response) {
 
   res.json(paginated);
 }
+
+// Função de recomendação de planos baseada na cidade e perfil de uso
+export function recommendation(req: Request, res: Response) {
+  const recomCity = String(req.query.recomCity || "");
+  const recomUsageProfile = String(req.query.recomUsageProfile || "");
+
+  // algumas validações no inicio da função ajudam a evitar processamento desnecessário. seguindo principios de fail fast.
+  if (!recomCity || !recomUsageProfile) {
+    return res.status(400).json([]);
+  }
+
+
+  // Função para normalizar strings (remover acentos e converter para minúsculas) é interessante porque facilita a comparação de strings, especialmente em casos onde os dados podem conter variações de acentuação ou capitalização.
+  const normalize = (str: string) =>
+    str.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
+
+  const plans = getPlans();
+
+  const cityPlans = plans.filter(
+    (p) => normalize(p.city) === normalize(recomCity)
+  );
+
+  // Se não houver planos na cidade especificada, retorna um erro 404.
+  if (cityPlans.length === 0) {
+    return res.status(404).json([]);
+  }
+
+  // Mapeamento do perfil de uso para categorias internas de recomendação
+  const usageMap: Record<string, string> = {
+    "1": "basico",
+    "2": "intermediario",
+    "3": "intermediario",
+    "4": "avancado",
+    "5": "avancado",
+    "6": "heavyUser",
+    "7": "avancado",
+    "8": "heavyUser",
+  };
+
+  const profileKey = usageMap[recomUsageProfile] || "intermediario";
+
+  // Regras de pontuação para cada perfil de uso
+  const rules: Record<string, { minSpeed: number; minDataCap: number }> = {
+    basico: { minSpeed: 50, minDataCap: 100 },
+    intermediario: { minSpeed: 150, minDataCap: 300 },
+    avancado: { minSpeed: 300, minDataCap: 600 },
+    heavyUser: { minSpeed: 600, minDataCap: 1000 },
+  };
+
+  const profile = rules[profileKey];
+
+  // Função para converter velocidades de string para número em Mbps
+  function parseSpeed(speed: string): number {
+    const lower = speed.toLowerCase();
+
+    if (lower.includes("gbps")) {
+      return parseFloat(lower.replace("gbps", "")) * 1000;
+    }
+
+    if (lower.includes("mbps")) {
+      return parseFloat(lower.replace("mbps", ""));
+    }
+
+    return 0;
+  }
+
+  // Calcula a pontuação de cada plano com base nas regras do perfil de uso
+  const scored = cityPlans.map((plan) => {
+    const speed = parseSpeed(plan.speed);
+    let score = 0;
+
+    if (speed >= profile.minSpeed) score += 50;
+    if (plan.dataCap >= profile.minDataCap) score += 30;
+
+    score += (1 / plan.price) * 10;
+
+    return { ...plan, score };
+  });
+
+  scored.sort((a, b) => b.score - a.score);
+
+  return res.json(scored[0],
+  );
+}
+
+
+
+
+

--- a/backend/src/routes/planRoutes.ts
+++ b/backend/src/routes/planRoutes.ts
@@ -3,6 +3,7 @@ import {
   allPlans,
   filteredPlans,
   planSearch,
+  recommendation,
 } from "../controllers/planController";
 
 const router = Router();
@@ -10,5 +11,6 @@ const router = Router();
 router.get("/", allPlans);
 router.get("/filtered", filteredPlans);
 router.get("/search", planSearch);
+router.get("/recommendation", recommendation);
 
 export default router;

--- a/backend/src/services/planService.ts
+++ b/backend/src/services/planService.ts
@@ -184,6 +184,7 @@ export const allPlansMock: Plan[] = [
 ];
 
 export function getPlans(): Plan[] {
+  // Retorna uma nova cópia do array para evitar mutabilidade externa
   return [...allPlansMock].sort((a, b) => a.price - b.price);
 }
 
@@ -191,33 +192,21 @@ export function getAllPlans(): Plan[] {
   return allPlansMock;
 }
 
-export function handleThing(
+// Renomeei a função para filterPlans, é o que ela realmente faz, filtra os planos.
+export function filterPlans(
   plans: Plan[],
   minSpeed?: number,
   maxPrice?: number
 ): Plan[] {
-  return plans
-    .filter((plan) => {
-      if (minSpeed) {
-        const speedValue = parseInt(plan.speed.replace("Mbps", ""));
-        if (speedValue < minSpeed) {
-          return false;
-        }
-      }
-      return true;
-    })
-    .filter((plan) => {
-      if (maxPrice && plan.price > maxPrice) {
-        return false;
-      }
-      return true;
-    })
-    .map((plan) => {
-      if (plan.price < 100) {
-        return { ...plan };
-      }
-      return plan;
-    });
+  // apenas um único filter é necessário aqui, tornando o código mais legível e eficiente.
+  return plans.filter((plan) => {
+    const speedValue = parseInt(plan.speed.replace("Mbps", ""));
+
+    const isSpeedOK = minSpeed ? speedValue >= minSpeed : true;
+    const isPriceOK = maxPrice ? plan.price <= maxPrice : true;
+
+    return isSpeedOK && isPriceOK;
+  });
 }
 
 export interface PlanSearchFilters {
@@ -281,6 +270,8 @@ export function searchPlans(
     filteredPlansCache = filtered;
     lastFiltersCache = filtersKey;
   }
+
+  // o problema estava a aqui, existia um erro de mutabilidade no cache, foi resolvido criando um novo array ao fatiar os planos.
 
   const total = filteredPlansCache?.length ?? 0;
   const totalPages = Math.ceil(total / pageSize);

--- a/backend/src/services/planService.ts
+++ b/backend/src/services/planService.ts
@@ -184,7 +184,7 @@ export const allPlansMock: Plan[] = [
 ];
 
 export function getPlans(): Plan[] {
-  return allPlansMock;
+  return [...allPlansMock].sort((a, b) => a.price - b.price);
 }
 
 export function getAllPlans(): Plan[] {
@@ -249,7 +249,7 @@ export function searchPlans(
   const filtersKey = JSON.stringify(filters);
 
   if (lastFiltersCache !== filtersKey) {
-    let filtered = allPlansMock;
+    let filtered = getPlans();
     if (filters.minPrice !== undefined) {
       filtered = filtered.filter((plan) => plan.price >= filters.minPrice!);
     }
@@ -282,15 +282,7 @@ export function searchPlans(
     lastFiltersCache = filtersKey;
   }
 
-  if (filteredPlansCache) {
-    if (page % 2 === 0) {
-      filteredPlansCache.sort((a, b) => b.price - a.price);
-    } else {
-      filteredPlansCache.sort((a, b) => a.price - b.price);
-    }
-  }
-
-  const total = filteredPlansCache ? filteredPlansCache.length : 0;
+  const total = filteredPlansCache?.length ?? 0;
   const totalPages = Math.ceil(total / pageSize);
   const start = (page - 1) * pageSize;
   const end = start + pageSize;

--- a/frontend/components/Modal.tsx
+++ b/frontend/components/Modal.tsx
@@ -6,6 +6,7 @@ type ModalProps = {
   children: React.ReactNode;
 };
 
+// Componente de Modal simples em React, para trabalhar a sugestão de plano de forma interativa, permitindo ao usuário fechar o modal ao clicar fora dele ou em um botão de fechar. Utilizei essa abordagem inspirado em ferramentas de inteligência de catálogo.
 export default function ReactModal({ isOpen, onClose, children }: ModalProps) {
   if (!isOpen) return null;
 

--- a/frontend/components/Modal.tsx
+++ b/frontend/components/Modal.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+type ModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+};
+
+export default function ReactModal({ isOpen, onClose, children }: ModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.55)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 9999,
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+            background: "#fff",
+            borderRadius: 12,
+            padding: 24,
+            minWidth: 300,
+            position: "relative",
+            display: "flex",
+            flexDirection: "column",
+            gap: 16,
+        }}
+        onClick={(e) => e.stopPropagation()}
+        >
+        <h1 style={{ fontSize: 24 }}>Encontre o melhor plano para você</h1>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/PlanCard.tsx
+++ b/frontend/components/PlanCard.tsx
@@ -1,5 +1,3 @@
-import styles from "../styles/Home.module.scss";
-
 interface Plan {
   id: number;
   name: string;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,9 +9,10 @@
       "version": "1.0.0",
       "dependencies": {
         "axios": "1.6.7",
+        "lucide-react": "^0.555.0",
         "next": "14.2.3",
         "react": "18.2.0",
-        "react-dom": "18.2.0",
+        "react-dom": "^18.2.0",
         "sass": "^1.89.2"
       },
       "devDependencies": {
@@ -922,6 +923,14 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.555.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.555.0.tgz",
+      "integrity": "sha512-D8FvHUGbxWBRQM90NZeIyhAvkFfsh3u9ekrMvJ30Z6gnpBHS6HC6ldLg7tL45hwiIz/u66eKDtdA23gwwGsAHA==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1110,7 +1119,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,9 +9,10 @@
   },
   "dependencies": {
     "axios": "1.6.7",
+    "lucide-react": "^0.555.0",
     "next": "14.2.3",
     "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "react-dom": "^18.2.0",
     "sass": "^1.89.2"
   },
   "devDependencies": {

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -84,6 +84,7 @@ export default function Home() {
       });
   }, []);
 
+  // Requisição de recomendação de planos baseada nos campos selecionados
   useEffect(() => {
   async function getRecommendation() {
     if (recomFields.recomCity && recomFields.recomUsageProfile) {
@@ -107,6 +108,7 @@ export default function Home() {
     }));
   }
 
+  // foi necessário criar uma função separada para lidar com as mudanças nos campos de recomendação, garantindo que o estado seja atualizado corretamente com base na entrada do usuário.
   async function handleRecommendationPlan(
   e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
 ) {
@@ -126,6 +128,7 @@ export default function Home() {
 
   return (
     <>
+      {/* Modal de recomendação de planos */}
       <ReactModal isOpen={isOpen} onClose={handleModal}>
         <button style={{ position: "absolute", top: 10, right: 10, cursor: "pointer", backgroundColor: "transparent", border: "none" }} onClick={() => setIsOpen(false)}><X /></button>
         <label style={{ color: "#00897b", fontWeight: 600, fontSize: 15 }}>
@@ -172,7 +175,7 @@ export default function Home() {
             </option>
           ))}
         </select>
-
+          { /* Exibe o plano recomendado se disponível, utilizando o mesmo componente já existente. */ }
         { recommendedPlans.id && <PlanCard key={recommendedPlans.id} plan={recommendedPlans} />}
 
       </ReactModal>

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from "react";
-import api, { fetchFilteredPlans, PlanSearchParams } from "../services/api";
+import api, { fetchFilteredPlans, PlanSearchParams, fetchRecommendations, RecommendationParams } from "../services/api";
 import PlanCard from "../components/PlanCard";
 import Menu from "../components/Menu";
 import Footer from "../components/Footer";
 import styles from "../styles/Home.module.scss";
+import ReactModal from "../components/Modal";
+import { X } from 'lucide-react'
 
 interface Plan {
   id: number;
@@ -37,6 +39,17 @@ const CITIES = [
   "Brasília",
 ];
 
+const USAGE_PROFILE = [
+  { label: "Redes sociais / Navegação / WhatsApp", value: "1" },
+  { label: "Aulas online / Reuniões (Zoom, Meet)", value: "2" },
+  { label: "Streaming HD (Netflix, YouTube)", value: "3" },
+  { label: "Streaming 4K / TV ao vivo", value: "4" },
+  { label: "Jogos online", value: "5" },
+  { label: "Download pesado / Upload de vídeos", value: "6" },
+  { label: "Trabalho remoto", value: "7" },
+  { label: "Casa com muitos dispositivos conectados", value: "8" },
+];
+
 export default function Home() {
   const [filters, setFilters] = useState<PlanSearchParams>({
     page: 1,
@@ -45,6 +58,14 @@ export default function Home() {
   const [result, setResult] = useState<PaginatedPlans | null>(null);
   const [loading, setLoading] = useState(false);
   const [planNames, setPlanNames] = useState<string[]>([]);
+  const [isOpen, setIsOpen] = useState(true);
+  const [recomFields, setRecomFields] = useState<RecommendationParams>({ recomCity: "", recomUsageProfile: "" });
+  const [recommendedPlans, setRecommendedPlans] = useState<Plan>({  } as Plan);
+
+
+  const handleModal = () => {
+    setIsOpen((prev) => !prev);
+  }
 
   useEffect(() => {
     setLoading(true);
@@ -63,6 +84,18 @@ export default function Home() {
       });
   }, []);
 
+  useEffect(() => {
+  async function getRecommendation() {
+    if (recomFields.recomCity && recomFields.recomUsageProfile) {
+      const plan = await fetchRecommendations(recomFields);
+      setRecommendedPlans(plan);
+    }
+  }
+
+  getRecommendation();
+}, [recomFields]);
+
+
   function handleChange(
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
   ) {
@@ -74,12 +107,75 @@ export default function Home() {
     }));
   }
 
+  async function handleRecommendationPlan(
+  e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+) {
+  const { name, value } = e.target;
+
+  setRecomFields((prev) => ({
+    ...prev,
+    [name]: value || "",
+  }));
+}
+
+
   function handlePageChange(newPage: number) {
     setFilters((prev) => ({ ...prev, page: newPage }));
   }
 
+
   return (
     <>
+      <ReactModal isOpen={isOpen} onClose={handleModal}>
+        <button style={{ position: "absolute", top: 10, right: 10, cursor: "pointer", backgroundColor: "transparent", border: "none" }} onClick={() => setIsOpen(false)}><X /></button>
+        <label style={{ color: "#00897b", fontWeight: 600, fontSize: 15 }}>
+          Cidade
+        </label>
+        <select
+          name="recomCity"
+          onChange={handleRecommendationPlan}
+          defaultValue=""
+          style={{
+            padding: 10,
+            borderRadius: 8,
+            border: "1.5px solid #b2dfdb",
+            background: "#fff",
+            fontSize: 15,
+          }}
+        >
+          <option value="">Selecione</option>
+          {CITIES.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+        <label style={{ color: "#00897b", fontWeight: 600, fontSize: 15 }}>
+          Selecione a opção que mais tem a ver com você
+        </label>
+        <select
+          name="recomUsageProfile"
+          onChange={handleRecommendationPlan}
+          defaultValue=""
+          style={{
+            padding: 10,
+            borderRadius: 8,
+            border: "1.5px solid #b2dfdb",
+            background: "#fff",
+            fontSize: 15,
+          }}
+        >
+          <option value="">Selecione</option>
+          {USAGE_PROFILE.map((c) => (
+            <option key={c.value} value={c.value}>
+              {c.label}
+            </option>
+          ))}
+        </select>
+
+        { recommendedPlans.id && <PlanCard key={recommendedPlans.id} plan={recommendedPlans} />}
+
+      </ReactModal>
       <Menu />
       <div style={{ display: "flex", alignItems: "flex-start" }}>
         {/* Sidebar de Filtros */}

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -22,3 +22,13 @@ export async function fetchFilteredPlans(params: PlanSearchParams) {
   const { data } = await api.get("/plans/search", { params });
   return data;
 }
+
+export interface RecommendationParams {
+  recomCity: string;
+  recomUsageProfile: string;
+} 
+
+export async function fetchRecommendations(params: RecommendationParams) {
+  const { data } = await api.get("/plans/recommendation", { params });
+  return data;
+}


### PR DESCRIPTION
## O que essa PR entrega

Esta PR implementa:

- Uma função `filterPlans` reescrita, mais limpa e eficiente, para filtrar planos por velocidade mínima e/ou preço máximo.  
- Uma nova rota GET `/plans/recommendation` que recebe `recomCity` e `recomUsageProfile` por query params e retorna um único plano recomendado ao usuário, com base em regras de perfil de uso.  
- Um algoritmo de recomendação que:
  - Normaliza cidade (removendo acentos/maiúsculas) para garantir compatibilidade com o cadastro.  
  - Converte corretamente velocidades em Mbps ou Gbps para valor numérico.  
  - Usa regras por perfil (básico, intermediário, avançado, heavy-user) definindo velocidade mínima e franquia mínima.  
  - Selecione o plano com maior “score” baseado em velocidade, franquia e custo-benefício (preço).  
- No frontend, um modal em React que permite ao usuário informar cidade + perfil, dispara a requisição automaticamente e exibe o plano recomendado via um componente `PlanCard`.  

---

## Motivações / Por que essas mudanças

- A função de filtros anterior estava pouco expressiva e pouco modular — renomear para `filterPlans` e simplificar torna o código mais legível e reutilizável.  
- A recomendação inteligente torna a aplicação mais completa e alinhada ao objetivo de sugerir planos de forma automatizada, com lógica simples e extensível.  
- Normalização de strings e parsing de velocidade tornam o sistema mais robusto frente a variações de input.  
- A interface via modal facilita a interação com o usuário para testes da feature, sem exigir um frontend sofisticado.  

---

## Como testar

- 🎯 Backend: usando uma tool de requisição ou diretamente pelo navegador, chamar endpoints como:  
  `GET /plans/recommendation?recomCity=São%20Paulo&recomUsageProfile=4`  
  Verificar se retorna o plano esperado (maior score conforme perfil).  
- Frontend: abrir a aplicação, o modal aparece, escolher cidade e perfil → o plano recomendado é exibido no modal via `PlanCard`.  

---

## Decisões técnicas e suposições

- Escolha por GET + query params para simplificar a interação e evitar corpo no request.  
- Perfis de uso mapeados via código numérico para categorias internas (básico, intermediário, etc.), com regras de velocidade e franquia.  
- Ao converter velocidades, considerar tanto "Mbps" quanto "Gbps" para garantir precisão.  
- Ao filtrar planos, aplicar tanto velocidade mínima quanto preço máximo, de forma combinada — função `filterPlans` modular e reutilizável.  

---

## Próximos passos / Possíveis melhorias

- Retornar `top N` recomendações em vez de apenas um plano.  
- Permitir mais critérios (ex: operadora, data cap, upload, tipo de uso familiar).  
- Adicionar testes unitários e de integração para recommendation + filtros.  
- Permitir personalização de regras de perfil sem alterar o código (configuração externa).  
